### PR TITLE
Fix: staff dropdown preselection issue in schedule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,78 @@
+# Claude Code documentation and analysis
+docs/Tim/claude/
+
+# Node.js frontend specific (if needed in future)
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+dist/
+build/
+
+# Environment variables
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# IDE files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS generated files
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Logs
+logs
+*.log
+
+# Runtime data
+pids
+*.pid
+*.seed
+
+# Coverage directory used by tools like istanbul
+coverage/
+
+# Dependency directories
+bower_components/
+
+# Optional npm cache directory
+.npm
+
+# Optional REPL history
+.node_repl_history
+
+# Temporary folders
+tmp/
+temp/
+
+# Editor backup files
+*.bak
+*.tmp
+
+# Web server files
+.htaccess
+
+# SSL certificates
+*.key
+*.crt
+*.pem
+
+# Database files
+*.sqlite
+*.db
+
+# Cache files
+.cache/
+.parcel-cache/

--- a/js/schedule.js
+++ b/js/schedule.js
@@ -95,7 +95,15 @@ function authHeader() {
     select.innerHTML = '<option value="">Select Staff</option>';
     allStaff.forEach((staff) => {
       const option = document.createElement("option");
-      option.value = staff.StaffId;
+      // =================================================================
+      // Bug Fix: Staff Dropdown Selection Issue
+      // Developer: Tim
+      // Date: 2025-09-25
+      // Description: Convert StaffId to string for proper dropdown selection
+      // Issue: Dropdown fails to preselect staff when editing shifts
+      // Bug Reference: Bug #2
+      // =================================================================
+      option.value = String(staff.StaffId);
       option.textContent = `${staff.FirstName} ${staff.LastName}`;
       select.appendChild(option);
     });
@@ -265,7 +273,15 @@ function authHeader() {
     if (shiftData) {
       shiftModalTitle.textContent = "Edit Shift";
       document.getElementById("shiftId").value = shiftData.ShiftId || "";
-      document.getElementById("shiftStaffId").value = shiftData.StaffId || "";
+      // =================================================================
+      // Bug Fix: Staff Preselection Type Consistency
+      // Developer: Tim
+      // Date: 2025-09-25
+      // Description: Ensure consistent string type for staff preselection
+      // Issue: Type mismatch prevents proper staff selection in edit mode
+      // Bug Reference: Bug #2
+      // =================================================================
+      document.getElementById("shiftStaffId").value = String(shiftData.StaffId || "");
       document.getElementById("shiftDate").value = shiftData.ShiftDate || "";
       document.getElementById("shiftStartTime").value =
         shiftData.StartTime || "";
@@ -380,11 +396,20 @@ function authHeader() {
     });
   }
 
-  document
-    .getElementById("shiftStaffId")
-    .addEventListener("change", async () => {
+  // =================================================================
+  // Bug Fix: Safe Event Listener Attachment
+  // Developer: Tim
+  // Date: 2025-09-25
+  // Description: Add null check for safer event listener attachment
+  // Issue: Potential null reference error if DOM element not found
+  // Bug Reference: Bug #2
+  // =================================================================
+  const shiftStaffSelect = document.getElementById("shiftStaffId");
+  if (shiftStaffSelect) {
+    shiftStaffSelect.addEventListener("change", async () => {
       overlapWarning.classList.add("d-none");
     });
+  }
 
   ["shiftDate", "shiftStartTime", "shiftEndTime"].forEach((id) => {
     document.getElementById(id).addEventListener("change", async () => {


### PR DESCRIPTION
  management (Bug #2)

  Resolve type mismatch preventing proper staff
  selection when editing shifts.
  Convert StaffId from number to string for
  consistent DOM value comparison.
@nguy1710  @tran0702 